### PR TITLE
Fix incorrect mod display name on Curseforge/Modrinth

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ publishMods {
         modLoaders.add("fabric")
         modLoaders.add("quilt")
         file = project(":fabric").tasks.named("remapJar").get().archiveFile
-        displayName = "Create: Estrogen ${rootProject.mod_version} Fabric"
+        displayName = "Chat Toggle ${rootProject.mod_version} Fabric"
         version = "${rootProject.mod_version}-fabric"
     }
 
@@ -75,7 +75,7 @@ publishMods {
         from optionsCurseforge
         modLoaders.add("neoforge")
         file = project(":neoforge").tasks.named("remapJar").get().archiveFile
-        displayName = "Create: Estrogen ${rootProject.mod_version} NeoForge"
+        displayName = "Chat Toggle ${rootProject.mod_version} NeoForge"
         version = "${rootProject.mod_version}-neoforge"
     }
 
@@ -84,7 +84,7 @@ publishMods {
         modLoaders.add("fabric")
         modLoaders.add("quilt")
         file = project(":fabric").tasks.named("remapJar").get().archiveFile
-        displayName = "Create: Estrogen ${rootProject.mod_version} Fabric"
+        displayName = "Chat Toggle ${rootProject.mod_version} Fabric"
         version = "${rootProject.mod_version}-fabric"
     }
 
@@ -92,7 +92,7 @@ publishMods {
         from optionsModrinth
         modLoaders.add("neoforge")
         file = project(":neoforge").tasks.named("remapJar").get().archiveFile
-        displayName = "Create: Estrogen ${rootProject.mod_version} NeoForge"
+        displayName = "Chat Toggle ${rootProject.mod_version} NeoForge"
         version = "${rootProject.mod_version}-neoforge"
     }
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1109b2a7-d062-4e53-8bf1-7791fe979cdc)
![image](https://github.com/user-attachments/assets/cbb07986-b0c1-4e79-91e1-18568481334e)

Only for 1.21 since issue isn't present on 1.18.2 branch (and the other ones don't have publishing set up)